### PR TITLE
Fix workspace error message grammar

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -14,7 +14,7 @@ function activate(context) {
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath;
 
     if (!workspaceFolder) {
-      vscode.window.showErrorMessage('No workspace opened.');
+      vscode.window.showErrorMessage('No workspace open.');
       return;
     }
 
@@ -42,7 +42,7 @@ function activate(context) {
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath;
 
     if (!workspaceFolder) {
-      vscode.window.showErrorMessage('No workspace opened.');
+      vscode.window.showErrorMessage('No workspace open.');
       return;
     }
 


### PR DESCRIPTION
## Summary
- fix grammar for workspace check message

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685703f35a3c832b95566abaff32e9fc